### PR TITLE
Add organizer data preparation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,42 @@ pip install -r requirements.txt
 ```
 
 ### 3. Prepare Data
-Ensure your images are in the `data/train` and `data/test` folders, and `labels_train.csv` is in the `data/` directory.
+If your source images are already organized as one folder per class, use
+`prepare_data.py` to create the competition layout automatically:
+
+```bash
+python prepare_data.py path/to/folder_per_class_dataset --output-dir data --overwrite
+```
+
+Example input:
+
+```text
+raw_dataset/
+  Cats/
+    cat_001.jpg
+    cat_002.jpg
+  Dogs/
+    dog_001.jpg
+    dog_002.jpg
+```
+
+The script writes:
+
+- `data/train/`: copied training images
+- `data/test/`: copied test images
+- `data/labels_train.csv`: `image_id,label` training labels
+- `data/secret_ground_truth.csv`: held-out test labels for organizers
+- `data/label_map.json`: class-name to integer-label mapping
+
+By default, `20%` of each class is held out for the test split. Adjust it with:
+
+```bash
+python prepare_data.py path/to/folder_per_class_dataset --test-ratio 0.3 --seed 123 --output-dir data --overwrite
+```
+
+If your data is already in competition format, ensure your images are in the
+`data/train` and `data/test` folders, and `labels_train.csv` is in the `data/`
+directory.
 
 ### 4. Training
 To train the baseline model, run:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The script writes:
 - `data/test/`: copied test images
 - `data/labels_train.csv`: `image_id,label` training labels
 - `data/secret_ground_truth.csv`: held-out test labels for organizers
-- `data/label_map.json`: class-name to integer-label mapping
+- `data/label_map.json`: integer-label to class-name mapping
 
 By default, `20%` of each class is held out for the test split. Adjust it with:
 

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -1,0 +1,190 @@
+import argparse
+import csv
+import json
+import random
+import shutil
+from pathlib import Path
+
+
+IMAGE_EXTENSIONS = {
+    ".jpeg",
+    ".jpg",
+    ".png",
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert a folder-per-class image dataset into the DetectX "
+            "competition data layout."
+        )
+    )
+    parser.add_argument(
+        "source_dir",
+        type=Path,
+        help="Directory containing one subdirectory per class.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data"),
+        help="Directory where train/test folders and CSV files will be written.",
+    )
+    parser.add_argument(
+        "--test-ratio",
+        type=float,
+        default=0.2,
+        help="Fraction of each class to place in the test split.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed used for the deterministic train/test split.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing output directory.",
+    )
+    return parser.parse_args()
+
+
+def find_class_dirs(source_dir):
+    if not source_dir.exists() or not source_dir.is_dir():
+        raise ValueError(f"source_dir is not a directory: {source_dir}")
+
+    class_dirs = sorted(path for path in source_dir.iterdir() if path.is_dir())
+    if not class_dirs:
+        raise ValueError(f"No class directories found in {source_dir}")
+    return class_dirs
+
+
+def find_images(class_dir):
+    return sorted(
+        path
+        for path in class_dir.rglob("*")
+        if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS
+    )
+
+
+def split_images(images, test_ratio, rng):
+    shuffled = list(images)
+    rng.shuffle(shuffled)
+
+    if not 0 <= test_ratio < 1:
+        raise ValueError("--test-ratio must be >= 0 and < 1")
+
+    test_count = int(round(len(shuffled) * test_ratio))
+    if test_ratio > 0 and len(shuffled) > 1:
+        test_count = max(1, min(test_count, len(shuffled) - 1))
+
+    test_images = shuffled[:test_count]
+    train_images = shuffled[test_count:]
+    return train_images, test_images
+
+
+def reset_output_dir(output_dir, overwrite):
+    if output_dir.exists():
+        if not overwrite:
+            raise FileExistsError(
+                f"{output_dir} already exists. Pass --overwrite to replace it."
+            )
+        shutil.rmtree(output_dir)
+
+    (output_dir / "train").mkdir(parents=True)
+    (output_dir / "test").mkdir(parents=True)
+
+
+def copy_split(images, split_dir, split_name, label_id, start_index):
+    rows = []
+    index = start_index
+    for image_path in images:
+        image_id = f"{split_name}_{index:06d}{image_path.suffix.lower()}"
+        shutil.copy2(image_path, split_dir / image_id)
+        rows.append({"image_id": image_id, "label": label_id})
+        index += 1
+    return rows, index
+
+
+def write_labels(path, rows):
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["image_id", "label"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def prepare_dataset(source_dir, output_dir, test_ratio, seed, overwrite):
+    class_dirs = find_class_dirs(source_dir)
+    reset_output_dir(output_dir, overwrite)
+
+    rng = random.Random(seed)
+    label_map = {}
+    train_rows = []
+    test_rows = []
+    train_index = 1
+    test_index = 1
+
+    for label_id, class_dir in enumerate(class_dirs):
+        images = find_images(class_dir)
+        if not images:
+            raise ValueError(f"No supported images found in class directory: {class_dir}")
+
+        label_map[class_dir.name] = label_id
+        train_images, test_images = split_images(images, test_ratio, rng)
+
+        rows, train_index = copy_split(
+            train_images,
+            output_dir / "train",
+            "train",
+            label_id,
+            train_index,
+        )
+        train_rows.extend(rows)
+
+        rows, test_index = copy_split(
+            test_images,
+            output_dir / "test",
+            "test",
+            label_id,
+            test_index,
+        )
+        test_rows.extend(rows)
+
+    write_labels(output_dir / "labels_train.csv", train_rows)
+    write_labels(output_dir / "secret_ground_truth.csv", test_rows)
+
+    with (output_dir / "label_map.json").open("w", encoding="utf-8") as handle:
+        json.dump(label_map, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    return {
+        "classes": len(label_map),
+        "train_images": len(train_rows),
+        "test_images": len(test_rows),
+        "label_map": label_map,
+    }
+
+
+def main():
+    args = parse_args()
+    summary = prepare_dataset(
+        source_dir=args.source_dir,
+        output_dir=args.output_dir,
+        test_ratio=args.test_ratio,
+        seed=args.seed,
+        overwrite=args.overwrite,
+    )
+
+    print(
+        "Prepared dataset: "
+        f"{summary['classes']} classes, "
+        f"{summary['train_images']} train images, "
+        f"{summary['test_images']} test images"
+    )
+    print(f"Wrote output to: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -1,10 +1,11 @@
+"""Prepare folder-per-class image datasets for the DetectX competition layout."""
+
 import argparse
 import csv
 import json
 import random
 import shutil
 from pathlib import Path
-
 
 IMAGE_EXTENSIONS = {
     ".jpeg",
@@ -14,6 +15,7 @@ IMAGE_EXTENSIONS = {
 
 
 def parse_args():
+    """Parse command-line arguments for the dataset preparation utility."""
     parser = argparse.ArgumentParser(
         description=(
             "Convert a folder-per-class image dataset into the DetectX "
@@ -52,6 +54,7 @@ def parse_args():
 
 
 def find_class_dirs(source_dir):
+    """Return sorted class directories from a folder-per-class dataset."""
     if not source_dir.exists() or not source_dir.is_dir():
         raise ValueError(f"source_dir is not a directory: {source_dir}")
 
@@ -62,6 +65,7 @@ def find_class_dirs(source_dir):
 
 
 def find_images(class_dir):
+    """Return supported image files under a class directory."""
     return sorted(
         path
         for path in class_dir.rglob("*")
@@ -70,6 +74,7 @@ def find_images(class_dir):
 
 
 def split_images(images, test_ratio, rng):
+    """Split one class of images into deterministic train and test subsets."""
     shuffled = list(images)
     rng.shuffle(shuffled)
 
@@ -86,6 +91,7 @@ def split_images(images, test_ratio, rng):
 
 
 def reset_output_dir(output_dir, overwrite):
+    """Create fresh train/test output directories."""
     if output_dir.exists():
         if not overwrite:
             raise FileExistsError(
@@ -98,6 +104,7 @@ def reset_output_dir(output_dir, overwrite):
 
 
 def copy_split(images, split_dir, split_name, label_id, start_index):
+    """Copy split images and return CSV label rows plus the next image index."""
     rows = []
     index = start_index
     for image_path in images:
@@ -109,6 +116,7 @@ def copy_split(images, split_dir, split_name, label_id, start_index):
 
 
 def write_labels(path, rows):
+    """Write image label rows using the competition CSV schema."""
     with path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=["image_id", "label"])
         writer.writeheader()
@@ -116,6 +124,7 @@ def write_labels(path, rows):
 
 
 def prepare_dataset(source_dir, output_dir, test_ratio, seed, overwrite):
+    """Convert a folder-per-class dataset into the DetectX competition format."""
     class_dirs = find_class_dirs(source_dir)
     reset_output_dir(output_dir, overwrite)
 
@@ -131,7 +140,7 @@ def prepare_dataset(source_dir, output_dir, test_ratio, seed, overwrite):
         if not images:
             raise ValueError(f"No supported images found in class directory: {class_dir}")
 
-        label_map[class_dir.name] = label_id
+        label_map[label_id] = class_dir.name
         train_images, test_images = split_images(images, test_ratio, rng)
 
         rows, train_index = copy_split(
@@ -168,6 +177,7 @@ def prepare_dataset(source_dir, output_dir, test_ratio, seed, overwrite):
 
 
 def main():
+    """Run the dataset preparation command-line workflow."""
     args = parse_args()
     summary = prepare_dataset(
         source_dir=args.source_dir,

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -1,0 +1,70 @@
+"""Tests for the folder-per-class dataset preparation utility."""
+
+import csv
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from prepare_data import prepare_dataset
+
+
+class PrepareDatasetTests(unittest.TestCase):
+    """Cover the generated competition files from a small source dataset."""
+
+    def test_prepare_dataset_writes_expected_files_and_label_map(self):
+        """Convert a two-class dataset and verify the organizer-facing outputs."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_dir = root / "raw"
+            output_dir = root / "data"
+
+            for class_name, extension in (("Cats", ".jpg"), ("Dogs", ".png")):
+                class_dir = source_dir / class_name
+                class_dir.mkdir(parents=True)
+                for index in range(2):
+                    (class_dir / f"{class_name.lower()}_{index}{extension}").write_text(
+                        "image",
+                        encoding="utf-8",
+                    )
+
+            summary = prepare_dataset(
+                source_dir=source_dir,
+                output_dir=output_dir,
+                test_ratio=0.5,
+                seed=123,
+                overwrite=False,
+            )
+
+            self.assertEqual(
+                summary,
+                {
+                    "classes": 2,
+                    "train_images": 2,
+                    "test_images": 2,
+                    "label_map": {0: "Cats", 1: "Dogs"},
+                },
+            )
+
+            with (output_dir / "label_map.json").open(encoding="utf-8") as handle:
+                self.assertEqual(json.load(handle), {"0": "Cats", "1": "Dogs"})
+
+            with (output_dir / "labels_train.csv").open(
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                train_rows = list(csv.DictReader(handle))
+            with (output_dir / "secret_ground_truth.csv").open(
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                test_rows = list(csv.DictReader(handle))
+
+            self.assertEqual([row["label"] for row in train_rows], ["0", "1"])
+            self.assertEqual([row["label"] for row in test_rows], ["0", "1"])
+            self.assertEqual(len(list((output_dir / "train").iterdir())), 2)
+            self.assertEqual(len(list((output_dir / "test").iterdir())), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `prepare_data.py` to convert a folder-per-class image dataset into the DetectX competition layout.
- Generate `data/train`, `data/test`, `labels_train.csv`, `secret_ground_truth.csv`, and `label_map.json` with deterministic class IDs.
- Document the organizer workflow in the README.

Closes #2.

## Validation
- Ran `prepare_data.py` against a temporary two-class fixture dataset and confirmed train/test files, both CSVs, and `label_map.json` were generated.
- Ran `python -m py_compile prepare_data.py`.
- Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated data-preparation tool that converts folder-per-class image datasets into the competition layout, with configurable train/test split and reproducible seeding; it outputs organized train/test folders and necessary label files.
* **Documentation**
  * README updated with examples and instructions for the data preparation workflow and output structure.
* **Tests**
  * Added unit tests validating dataset preparation, output files, and label mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->